### PR TITLE
FIX CB references

### DIFF
--- a/docs/context_broker.md
+++ b/docs/context_broker.md
@@ -24,7 +24,9 @@ If you are interested in more details about how to make your application a conte
 
 ## API Reference Documentation ##
 
-- [API V1](http://telefonicaid.github.io/fiware-orion/api/v1/)
-- [API V2](http://telefonicaid.github.io/fiware-orion/api/v2/cookbook/) ongoing, not yet suitable for production
+- [API V1 Walkthrough](http://fiware-orion.readthedocs.org/en/develop/user/walkthrough_apiv1/index.html)
+- API V2 - ongoing, not yet suitable for production
+  - [Cookbook](http://telefonicaid.github.io/fiware-orion/api/v2/cookbook/)
+  - [Full reference](http://telefonicaid.github.io/fiware-orion/api/v2/)
 
 


### PR DESCRIPTION
There are three broken links, pointint to a non-existsing document context_broker_detail.md. I could try to fix in this same PR if I get some information from @joser or @javiergp regarding the original idea of these links and where they should point.