### PR TITLE
task/add_data_persistence_section

### DIFF
--- a/docs/cygnus.md
+++ b/docs/cygnus.md
@@ -12,9 +12,6 @@ Current stable release is able to persist the following sources of data in the f
     * [CKAN](http://ckan.org/), an Open Data platform.
     * [MongoDB](https://www.mongodb.org/), the NoSQL document-oriented database.
     * [FIWARE Comet (STH)](https://github.com/telefonicaid/IoT-STH), a Short-Term Historic database built on top of MongoDB.
-    * [Kafka](http://kafka.apache.org/), the publish-subscribe messaging broker.
-    * [DynamoDB](https://aws.amazon.com/dynamodb/), a cloud-based NoSQL database by [Amazon Web Services](https://aws.amazon.com/).
-    * [CartoDB](https://cartodb.com/), the database specialized in geolocated data.
 
 ## Documentation and API
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,15 @@ FIWARE IoT Stack provides also an [admin website](portal.md) for performing most
 - Send commands to devices
 - Set up simple notifications based on data.
 
+## Data persistence
+
+FIWARE IoT Data capabilities go far beyond querying the current context data or the short-term history. FIWARE IoT Stack provides means for storing hitorical data for the mid and long-term in third-party components; the following ones:
+
+- [HDFS](http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html), the [Hadoop](http://hadoop.apache.org/) distributed file system.
+- [MySQL](https://www.mysql.com/), the well-know relational database manager.
+- [CKAN](http://ckan.org/), an Open Data platform.
+- [MongoDB](https://www.mongodb.org/), the NoSQL document-oriented database.
+
 ## FIWARE Components
 
 FIWARE IoT Stack is based on the following [FIWARE components](walkthrough.md) in order to provide its functionality:

--- a/docs/naming_conventions.md
+++ b/docs/naming_conventions.md
@@ -1,0 +1,52 @@
+The platform impose several constraints with regards to the naming of the persistence elements (files, databases, tables and collections). Such constraints, and the way the different storages solve them, must be had into account when designing the data model of the solution running on top of the platform.
+
+#Global character set and size limitations
+Globally, the platform impose certain rules when defining the data model. These rules directly come from Orion Context Broker [constraints]((http://fiware-orion.readthedocs.io/en/develop/user/forbidden_characters/index.html)) regarding the character set used for entity and attribute names and their types: 
+
+* The following charaters are forbidden: `<`, `>`, `"`, `'`, `=`, `;`, `(` and `)`.
+* The following ones should also be avoided: white space, `?`, `/`, `%` and `&`.
+
+Additionally, Orion Context Broker imposes the following restrictions:
+
+* The [FIWARE-service](http://fiware-orion.readthedocs.io/en/develop/user/multitenancy/index.html) must be a string of alphanumeric characters including the underscore, whose maximum length is 50 characters.
+* The [FIWARE-servicePath](http://fiware-orion.readthedocs.io/en/develop/user/service_path/index.html) must be a string defining a Unix-like path starting with slash and having maximum 10 levels; being each level a string of alphanumeric characters including the underscore, whose maximum lenght is 50 characters. Nevertheless, the platform currently only allows a single level.
+
+All these limitations imposed by Orion Context Broker are propagated to the storages via Cygnus connectors with HDFS, MySQL, CKAN and MongoDB/STH.
+
+#HDFS character set and size limitations
+Persisting context data in [HDFS](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_hdfs_sink/index.html) implies creating folders and files, whose path names are constrained to 64 character strings of alphanumerics and underscore:
+
+    hdfs:///user/<FIWARE-service>/<FIWARE-servicePath>/<entityID>_<entityType>/<entityID>_<entityType>.txt
+
+Any other character within the FIWARE-service, FIWARE-servicePath, entity ID and type different than alphanumerics and underscore is replaced by underscore.
+
+#MySQL character set and size limitations
+Persisting context data in [MySQL](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_mysql_sink/index.html) implies creating databases and tables, whose names are constrained to 64 character strings of alphanumerics and underscore:
+
+* Databases: `<FIWARE-service>`
+* Tables: `<FIWARE-servicePath>_<entityID>_<entityType>`.
+
+Any other character within the FIWARE-service, FIWARE-servicePath, entity ID and type different than alphanumerics and underscore is replaced by underscore.
+
+#CKAN character set and size limitations
+Persisting context data in [CKAN](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_ckan_sink/index.html) implies creating organization, packages and resurces, whose names are constrained to 64 character strings of alphanumerics and underscore:
+
+* Organizations: `<FIWARE-service>`.
+* Packages: `<FIWARE-service>_<FIWARE-servicePath>`.
+* Resources: `<entityID>_<entityType>`.
+
+Any other character within the FIWARE-service, FIWARE-servicePath, entity ID and type different than alphanumerics and underscore is replaced by underscore.
+
+#MongoDB/STH character set and size limitations
+Persisting context data in [MongoDB](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_mongo_sink/index.html)/[STH](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_sth_sink/index.html) implies creating databases and collections:
+
+* Databases: `<FIWARE-service>`.
+* Collections: `<FIWARE-servicePath>`.
+
+Whose names are constrained this way by [MongoDB](https://docs.mongodb.com/manual/reference/limits/#naming-restrictions):
+
+* `/`, `\`, `.`, `"` and `$` are not accepted in the database names. Database names cannot be empty and must have fewer than 64 characters.
+* `$`, the empty string and the null character are not accepted in the collection names. In addition, collections cannot start with the `.system` prefix. The maximum length of the collection namespace, which includes the database name, the dot separator, and the collection name (i.e. `<database>.<collection>`), is 120 bytes.
+
+Nevertheless, the above restrictions does not affect the platform because of the limitations imposed to the FIWARE-service and the FIWARE-servicePath.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,8 @@ pages:
     - 'Management API': 'management_api.md'
   - 'Multitenancy: Service and Subservice': 'multitenancy.md'
   - 'Management Portal': 'portal.md'
+  - 'Data persistence':
+    - 'Naming conventions': 'naming_conventions.md'
   - 'Architecture':
     - 'FIWARE Components': 'walkthrough.md'
     - 'IoT Agents (IoTA)': 'device_gateway.md'


### PR DESCRIPTION
Adds a section about current Data Persistence.

This version does not have into account the encoding solution nor the attribute renaming solution we envision regarding the forbidden characters issue.

This version does not have into account the per-sink size limitation checks we envision as well.