### PR TITLE
task/fix_component_links_according_to_iotp_v4.1

### DIFF
--- a/docs/context_broker.md
+++ b/docs/context_broker.md
@@ -18,12 +18,12 @@ One of the most important features of the Context Broker is that it allows to mo
 
 ## API Reference Documentation ##
 
-- [API V2 Walkthrough](http://fiware-orion.readthedocs.org/en/develop/user/walkthrough_apiv2/index.html)
+- [API V2 Walkthrough](http://fiware-orion.readthedocs.io/en/1.4.0/user/walkthrough_apiv2/index.html)
 - [Cookbook](http://telefonicaid.github.io/fiware-orion/api/v2/stable/cookbook/)
 - [NGSIv2 full specification (RC 2016.05)](http://telefonicaid.github.io/fiware-orion/api/v2/stable)
 
 ## Orion Context Broker references
 
 - [Introduction to Context Management and Orion Context Broker](http://bit.ly/fiware-orion) (slideshare)
-- [User & Administrator Manual](https://fiware-orion.readthedocs.io/en/develop/)
+- [User & Administrator Manual](https://fiware-orion.readthedocs.io/en/1.4.0/)
 - [Source code repository](https://github.com/telefonicaid/fiware-orion)

--- a/docs/cygnus.md
+++ b/docs/cygnus.md
@@ -11,7 +11,7 @@ Current stable release is able to persist the following sources of data in the f
     * [MySQL](https://www.mysql.com/), the well-know relational database manager.
     * [CKAN](http://ckan.org/), an Open Data platform.
     * [MongoDB](https://www.mongodb.org/), the NoSQL document-oriented database.
-    * [FIWARE Comet (STH)](https://github.com/telefonicaid/IoT-STH), a Short-Term Historic database built on top of MongoDB.
+    * [FIWARE Comet (STH)](https://github.com/telefonicaid/fiware-sth-comet), a Short-Term Historic database built on top of MongoDB.
 
 ## Documentation and API
 

--- a/docs/historicdata_api.md
+++ b/docs/historicdata_api.md
@@ -10,6 +10,7 @@ Before being able to consume historical and aggregated time series information, 
 To do it, a subscription from the Short Time Historic (STH) to the Context Broker is needed, specifying the concrete entities and attributes of interest for which the historical and aggregated time series information should be generated.
 
 An example of such a subscription is included next. The concrete template values between `{{`and `}}` should be substituted by the real counterparts:
+
 ```
 POST /NGSI10/subscribeContext HTTP/1.1
 Host: test.ttcloud.net:1026
@@ -38,6 +39,7 @@ X-Auth-Token: {{user-token}}
   "throttling": "PT1S"
 }
 ```
+
 Notice that as a result of the previous subscription the platform will generate historical and aggregated time series context information about the `mydevice` entity of type `device` for each new attribute value notified by that device to the platform for the next year as set in the `duration` property.
 
 # Historical context information retrieval
@@ -45,6 +47,7 @@ Notice that as a result of the previous subscription the platform will generate 
 Once the historical and aggregated time series context information for the device of interest is activated, it can be retrieved from the platform.
 
 For example, to get the last 10 values of the  `temperature` attribute registered by the device of interest, a request such as the following one should be sent to the platform:
+
 ```
 GET /STH/v1/contextEntities/type/device/id/mydevice/attributes/temperature?lastN=10 HTTP/1.1
 Host: test.ttcloud.net:8666
@@ -54,9 +57,11 @@ Fiware-Service: {{Fiware-Service}}
 Fiware-ServicePath: {{Fiware-ServicePath}}
 X-Auth-Token: {{user-token}}
 ```
+
 Obviously, the `temperature` attribute could be changed by any other attribute for which the device of interest is registering values into the platform.
 
 The Historical Data API also supports pagination by means of the `hLimit`and `hOffset` query parameters. For example, to get the first 3 temperature values from the specified date, a request such as the following should be sent to the platform:
+
 ```
 GET /STH/v1/contextEntities/type/device/id/mydevice/attributes/temperature?hLimit=3&hOffset=0&dateFrom=2014-02-14T00:00:00.00
 Host: test.ttcloud.net:8666
@@ -66,7 +71,9 @@ Fiware-Service: {{Fiware-Service}}
 Fiware-ServicePath: {{Fiware-ServicePath}}
 X-Auth-Token: {{user-token}}
 ```
+
 As a result of the previous requests, a set of attribute values including their associated timestamps (this is, the concrete date and time when they were registered into the platform) will be returned, such as the following one:
+
 ```
 HTTP 200 OK
 Content-Type : application/json
@@ -107,6 +114,7 @@ Content-Type : application/json
 }
 
 ```
+
 Please, take into account that currently the Historical Data API only makes it possible to get historical context information associated to one concrete attribute (i.e. temperature, hummidity, etc.) per request.
 
 # Aggregated time series context information retrieval
@@ -114,6 +122,7 @@ Please, take into account that currently the Historical Data API only makes it p
 Apart from exposing historical context information, the Historical Data API also exposes aggregated time series context information about the entities and attributes of interest.
 
 This aggregated time series context information makes it possible, for example, to get the maximum temperature values registered into the platform by certain device during certain period of time and grouped by certain time or resolution, such as in the next request:
+
 ```
 GET /STH/v1/contextEntities/type/device/id/mydevice/attributes/temperature?aggrMethod=sum&aggrPeriod=second&dateFrom=2015-02-22T00:00:00.000Z&dateTo=2015-02-22T23:00:00.000Z
 Host: test.ttcloud.net:8666
@@ -137,6 +146,7 @@ Currently, the Historical Data API supports the next  `aggrMethod` query paramet
 On the other hand, the supported values for the `aggrPeriod` query parameter (which makes it possible to set the time by which the context information should be grouped) are: `second`, `minute`, `hour`, `day` and `month`.
 
 A typical response to an aggregated time series context information request such as the previous one is the following:
+
 ```
 HTTP 200 OK
 Content-Type : application/json
@@ -182,6 +192,7 @@ Content-Type : application/json
   ]
 }
 ```
+
 As you can see, the response includes an `origin` of time from which the `offset`s returned are referenced for the `resolution` or aggregation period requested.
 
 # In more detail ...

--- a/docs/naming_conventions.md
+++ b/docs/naming_conventions.md
@@ -1,27 +1,27 @@
 The platform impose several constraints with regards to the naming of the persistence elements (files, databases, tables and collections). Such constraints, and the way the different storages solve them, must be had into account when designing the data model of the solution running on top of the platform.
 
 #Global character set and size limitations
-Globally, the platform impose certain rules when defining the data model. These rules directly come from Orion Context Broker [constraints]((http://fiware-orion.readthedocs.io/en/develop/user/forbidden_characters/index.html)) regarding the character set used for entity and attribute names and their types: 
+Globally, the platform impose certain rules when defining the data model. These rules directly come from Orion Context Broker [constraints](http://fiware-orion.readthedocs.io/en/1.4.0/user/forbidden_characters/index.html) regarding the character set used for entity and attribute names and their types: 
 
 * The following charaters are forbidden: `<`, `>`, `"`, `'`, `=`, `;`, `(` and `)`.
 * The following ones should also be avoided: white space, `?`, `/`, `%` and `&`.
 
 Additionally, Orion Context Broker imposes the following restrictions:
 
-* The [FIWARE-service](http://fiware-orion.readthedocs.io/en/develop/user/multitenancy/index.html) must be a string of alphanumeric characters including the underscore, whose maximum length is 50 characters.
-* The [FIWARE-servicePath](http://fiware-orion.readthedocs.io/en/develop/user/service_path/index.html) must be a string defining a Unix-like path starting with slash and having maximum 10 levels; being each level a string of alphanumeric characters including the underscore, whose maximum lenght is 50 characters. Nevertheless, the platform currently only allows a single level.
+* The [FIWARE-service](http://fiware-orion.readthedocs.io/en/1.4.0/user/multitenancy/index.html) must be a string of alphanumeric characters including the underscore, whose maximum length is 50 characters.
+* The [FIWARE-servicePath](http://fiware-orion.readthedocs.io/en/1.4.0/user/service_path/index.html) must be a string defining a Unix-like path starting with slash and having maximum 10 levels; being each level a string of alphanumeric characters including the underscore, whose maximum lenght is 50 characters. Nevertheless, the platform currently only allows a single level.
 
 All these limitations imposed by Orion Context Broker are propagated to the storages via Cygnus connectors with HDFS, MySQL, CKAN and MongoDB/STH.
 
 #HDFS character set and size limitations
-Persisting context data in [HDFS](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_hdfs_sink/index.html) implies creating folders and files, whose path names are constrained to 64 character strings of alphanumerics and underscore:
+Persisting context data in [HDFS](http://fiware-cygnus.readthedocs.io/en/1.5.0/cygnus-ngsi/flume_extensions_catalogue/ngsi_hdfs_sink/index.html) implies creating folders and files, whose path names are constrained to 64 character strings of alphanumerics and underscore:
 
     hdfs:///user/<FIWARE-service>/<FIWARE-servicePath>/<entityID>_<entityType>/<entityID>_<entityType>.txt
 
 Any other character within the FIWARE-service, FIWARE-servicePath, entity ID and type different than alphanumerics and underscore is replaced by underscore.
 
 #MySQL character set and size limitations
-Persisting context data in [MySQL](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_mysql_sink/index.html) implies creating databases and tables, whose names are constrained to 64 character strings of alphanumerics and underscore:
+Persisting context data in [MySQL](http://fiware-cygnus.readthedocs.io/en/1.5.0/cygnus-ngsi/flume_extensions_catalogue/ngsi_mysql_sink/index.html) implies creating databases and tables, whose names are constrained to 64 character strings of alphanumerics and underscore:
 
 * Databases: `<FIWARE-service>`
 * Tables: `<FIWARE-servicePath>_<entityID>_<entityType>`.
@@ -29,7 +29,7 @@ Persisting context data in [MySQL](http://fiware-cygnus.readthedocs.io/en/latest
 Any other character within the FIWARE-service, FIWARE-servicePath, entity ID and type different than alphanumerics and underscore is replaced by underscore.
 
 #CKAN character set and size limitations
-Persisting context data in [CKAN](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_ckan_sink/index.html) implies creating organization, packages and resurces, whose names are constrained to 64 character strings of alphanumerics and underscore:
+Persisting context data in [CKAN](http://fiware-cygnus.readthedocs.io/en/1.5.0/cygnus-ngsi/flume_extensions_catalogue/ngsi_ckan_sink/index.html) implies creating organization, packages and resurces, whose names are constrained to 64 character strings of alphanumerics and underscore:
 
 * Organizations: `<FIWARE-service>`.
 * Packages: `<FIWARE-service>_<FIWARE-servicePath>`.
@@ -38,7 +38,7 @@ Persisting context data in [CKAN](http://fiware-cygnus.readthedocs.io/en/latest/
 Any other character within the FIWARE-service, FIWARE-servicePath, entity ID and type different than alphanumerics and underscore is replaced by underscore.
 
 #MongoDB/STH character set and size limitations
-Persisting context data in [MongoDB](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_mongo_sink/index.html)/[STH](http://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/orion_sth_sink/index.html) implies creating databases and collections:
+Persisting context data in [MongoDB](http://fiware-cygnus.readthedocs.io/en/1.5.0/cygnus-ngsi/flume_extensions_catalogue/ngsi_mongo_sink/index.html)/[STH](http://fiware-cygnus.readthedocs.io/en/1.5.0/cygnus-ngsi/flume_extensions_catalogue/ngsi_sth_sink/index.html) implies creating databases and collections:
 
 * Databases: `<FIWARE-service>`.
 * Collections: `<FIWARE-servicePath>`.

--- a/docs/topics/cep_new_actions.md
+++ b/docs/topics/cep_new_actions.md
@@ -7,7 +7,7 @@ However, it may happen that at a given moment of time, the current actions set i
 and you need new actions. In that case you have basically two options:
 
 * Develop a software module encapsulating your action and connect it with the 
-  [generic HTTP POST action](https://github.com/telefonicaid/perseo-fe/blob/master/documentation/plain_rules.md#http-request-action). 
+  [generic HTTP POST action](https://github.com/telefonicaid/perseo-fe/blob/release/1.3.0/documentation/plain_rules.md#http-request-action). 
   That is basically, a module exposing a REST API that CEP can invoke by the means of HTTP 
   POST requests. When your module receives the POST call from CEP then the actual action is executed. Note that HTTP POST
   requests can be parametrized using information from the events triggering the rule, so this alternative can be pretty

--- a/docs/topics/character_set_limitations.md
+++ b/docs/topics/character_set_limitations.md
@@ -3,7 +3,7 @@
 There are several charset and naming limitations to take into account when using the platform. In particular:
 
 - General restrictions in the [Data API](../data_api.md) exposed by [Context Broker](../context_broker.md)
-  due to security reasons. The details are provided in the [Context Broker documentation](https://fiware-orion.readthedocs.io/en/master/user/forbidden_characters/index.html) itself.
+  due to security reasons. The details are provided in the [Context Broker documentation](https://fiware-orion.readthedocs.io/en/1.4.0/user/forbidden_characters/index.html) itself.
 - Apart from the general restrictions above, there are some additional ones that apply to ID fields such as 
   the entity id or the attribute name. They are described in the section "Field syntax restrictions"
   at the [NGSIv2 specification](http://telefonicaid.github.io/fiware-orion/api/v2/stable/).

--- a/docs/topics/data_calculation.md
+++ b/docs/topics/data_calculation.md
@@ -101,7 +101,7 @@ or the same entity in NGSIv2 format:
       }
 
 To see the complete set of operations and features available for the Expression Language, refer to
-the [specification](https://github.com/telefonicaid/iotagent-node-lib/blob/master/doc/expressionLanguage.md).
+the [specification](https://github.com/telefonicaid/iotagent-node-lib/blob/2.4.0/doc/expressionLanguage.md).
 
 ## Calculations based on data in Context Entities
 

--- a/docs/topics/data_calculation.md
+++ b/docs/topics/data_calculation.md
@@ -108,11 +108,12 @@ the [specification](https://github.com/telefonicaid/iotagent-node-lib/blob/maste
 For those data values that doesn't come from devices, but from external systems, and for those cases when the sources of
 context information to calculate those values are multiple, the [CEP](../cep.md) can be used to make some of those calculations.
 
-The CEP gets a notification cointaining a configurable set of attributes (as set in the subscription) and that allows using more fields than the ones sent by device. The notification mechanism allows to send the previous value of an attribute as metadata `previousValue` (see [metadata in notifications](http://fiware-orion.readthedocs.io/en/master/user/metadata/index.html#metadata-in-notifications)). So, as an example, we can think of an entity that periodically sends its coordinates and the time of the measure. We could calculate its average velocity by means of a rule that updates its field `velocity`.
+The CEP gets a notification cointaining a configurable set of attributes (as set in the subscription) and that allows using more fields than the ones sent by device. The notification mechanism allows to send the previous value of an attribute as metadata `previousValue` (see [metadata in notifications](http://fiware-orion.readthedocs.io/en/1.4.0/user/metadata/index.html#metadata-in-notifications)). So, as an example, we can think of an entity that periodically sends its coordinates and the time of the measure. We could calculate its average velocity by means of a rule that updates its field `velocity`.
 
-For simplicity, the previous values are taken as values in the incomming notification, but they could be taken as `ev.x__metadata__previousValue` instead of `x0`, and the same for `y0` and `t0` (see [Metadata and object values](https://github.com/telefonicaid/perseo-fe/blob/master/documentation/plain_rules.md#metadata-and-object-values))
+For simplicity, the previous values are taken as values in the incomming notification, but they could be taken as `ev.x__metadata__previousValue` instead of `x0`, and the same for `y0` and `t0` (see [Metadata and object values](https://github.com/telefonicaid/perseo-fe/blob/1.3.0/documentation/plain_rules.md#metadata-and-object-values))
 
-The rule could be 
+The rule could be:
+
 ```
 {
     "name": "rule_velocity",
@@ -132,7 +133,8 @@ The rule could be
 }
 ```
 
-And a notification like
+And a notification like:
+
 ```
 {
     "subscriptionId": "51c04a21d714fb3b37d7d5a7",
@@ -185,7 +187,7 @@ And a notification like
 }
 ```
 
-would generate an update action
+would generate an update action:
 
 ```
 {  
@@ -207,10 +209,9 @@ would generate an update action
 }
 ```
 
-that woud set the field `velocity` to `2` (10/5) in whatever magnitudes we were using
+that woud set the field `velocity` to `2` (10/5) in whatever magnitudes we were using.
 
 All the functions in [java.lang.Math](https://docs.oracle.com/javase/7/docs/api/java/lang/Math.html) can be used in the EPL expression.
-
 
 ## Statistical calculations based on historic values
 
@@ -259,4 +260,4 @@ http://<sth-component>:<sth-port>/STH/v1/contextEntities/type/Entity/id/WasteTan
 http://<sth-component>:<sth-port>/STH/v1/contextEntities/type/Entity/id/WasteTank8/attributes/density?aggrMethod=sum2&aggrPeriod=minute&dateFrom=2016-11-14T00:00:00&dateTo=2016-11-16T23:59:59
 ```
 
-For futher information about the STH component and all the capabilities it provides, please visit the [STH documentation at ReadTheDocs](http://fiware-sth-comet.readthedocs.io/en/latest/index.html).
+For futher information about the STH component and all the capabilities it provides, please visit the [STH documentation at ReadTheDocs](http://fiware-sth-comet.readthedocs.io/en/release-2.1.0/).

--- a/docs/topics/geolocalized_entities.md
+++ b/docs/topics/geolocalized_entities.md
@@ -87,7 +87,7 @@ Once the entities location is correctly configured, it can be exploited at diffe
 
 - At the [CEP API](../cep_api.md). CEP is able to process entity point locations
   (other shapes as line, polygon, etc. not yet supported) so its latitude and
-  longitude can be easily used in EPL conditions. See [CEP documentation](https://github.com/telefonicaid/perseo-fe/blob/master/documentation/plain_rules.md#location-fields) for more detail. For example, the following rule will send an email when the entity with attribute `location` is 
+  longitude can be easily used in EPL conditions. See [CEP documentation](https://github.com/telefonicaid/perseo-fe/blob/1.3.0/documentation/plain_rules.md#location-fields) for more detail. For example, the following rule will send an email when the entity with attribute `location` is 
   less than 5 km far away from Cuenca. It uses the circle equation, `(x - a)^2 + (y - b)^2 = d^2`, being (a, b) 618618.8286057833 and 
   9764160.736945232 the UTMC coordinates of Cuenca and d the distance of 5000 m.
 

--- a/docs/topics/geolocalized_entities.md
+++ b/docs/topics/geolocalized_entities.md
@@ -119,5 +119,5 @@ Once the entities location is correctly configured, it can be exploited at diffe
 To include in the Persisente backends section, once Carto sink would be ready for production usage:
 
   - Carto. Both point and arbitrary GeoJSON location are supported and correctly persisted
-    at Carto. See [Cygnus documentation](http://fiware-cygnus.readthedocs.io/en/master/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink/index.html#section2.3.6) for more detail.
+    at Carto. See [Cygnus documentation](http://fiware-cygnus.readthedocs.io/en/1.5.0/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink/index.html#section2.3.6) for more detail.
 --> 

--- a/docs/topics/geolocalized_entities.md
+++ b/docs/topics/geolocalized_entities.md
@@ -72,8 +72,6 @@ With this configuration, information from the car can be reported with the follo
 
     s|55|la|40.392|lo|-3.759
 
-
-
 This will generate an update request to the context broker, setting the value of the attribute `location` to the value
 `40.392, -3.759`, as defined by the expression.
 
@@ -109,8 +107,8 @@ Once the entities location is correctly configured, it can be exploited at diffe
 
 - Persistence backends:
     - CKAN (column mode): there are two ways of providing location, either using two columns (one for latitude
-    another for longitude) or joining both in a single colum. See [Cygnus documentation](https://fiware-cygnus.readthedocs.io/en/latest/cygnus-ngsi/flume_extensions_catalogue/ngsi_ckan_sink/index.html#section2.3.4) for more detail. Note this is not the standard way of mark entity location in the Data API (see aforementioned "Geospacial properties of entities" section) and probably would be aligned in the
-    future to work in a similar way to the [Carto experimental persistence sink](http://fiware-cygnus.readthedocs.io/en/master/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink/index.html#section2.3.6).
+    another for longitude) or joining both in a single colum. See [Cygnus documentation](https://fiware-cygnus.readthedocs.io/en/1.5.0/cygnus-ngsi/flume_extensions_catalogue/ngsi_ckan_sink/index.html#section2.3.4) for more detail. Note this is not the standard way of mark entity location in the Data API (see aforementioned "Geospacial properties of entities" section) and probably would be aligned in the
+    future to work in a similar way to the [Carto experimental persistence sink](http://fiware-cygnus.readthedocs.io/en/1.5.0/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink/index.html#section2.3.6).
 
     ![CKAN grid view](images/ckan_grid_geolocation_example.png)
 

--- a/docs/topics/how_notifications_work.md
+++ b/docs/topics/how_notifications_work.md
@@ -181,7 +181,7 @@ an update with the value 67 then it *doesn't* send a notification.
 For those use cases that needs notifying each update (no matter if it results on actual value change or not), the
 IoTAgent implements a clever mechanism based on adding a `TimeInstant` metadata with the timestamp of the update. 
 This way, it is ensured that from a logical point of view the attribute always changes, as a change in any metadata 
-is considered a change in the attribute. Look for the `TimeInstant` element documentation in the [IoT Agent documentation](https://github.com/telefonicaid/iotagent-node-lib#the-timeinstant-element).
+is considered a change in the attribute. Look for the `TimeInstant` element documentation in the [IoT Agent documentation](https://github.com/telefonicaid/iotagent-node-lib/tree/release/2.4.0#the-timeinstant-element).
 
 In the case of client-provided entities (i.e. entities not managed by IoTAgent but by your application) you may need a 
 similar mechanism. In this case, ensure that the `TimeInstant` metadata resolution is high enough, e.g. if your system

--- a/docs/topics/how_notifications_work.md
+++ b/docs/topics/how_notifications_work.md
@@ -169,7 +169,7 @@ resulting in notifications like this one:
     Car BCZ6754 speed is 57 km/h. Be careful you could be fined!
 
 This is just a brief introduction to the overall subscriptions/notifications functionality. You can find
-the full details and more examples at the [Context Broker documentation](https://fiware-orion.readthedocs.io/en/master/user/walkthrough_apiv2/index.html#subscriptions) and the "Subscriptions" section at the
+the full details and more examples at the [Context Broker documentation](https://fiware-orion.readthedocs.io/en/1.4.0/user/walkthrough_apiv2/index.html#subscriptions) and the "Subscriptions" section at the
 [NGSIv2 specification](http://telefonicaid.github.io/fiware-orion/api/v2/stable/).
 
 ## The `TimeInstant` metadata

--- a/docs/topics/subcriptions_and_registrations.md
+++ b/docs/topics/subcriptions_and_registrations.md
@@ -20,12 +20,12 @@ On the one hand, subscriptions:
 On the other hand, registrations:
 
 - Are used to configure context sources (also known as *context providers*). Details can be found in 
-  [the Context Broker documentation](http://fiware-orion.readthedocs.io/en/master/user/context_providers/index.html).
+  [the Context Broker documentation](http://fiware-orion.readthedocs.io/en/1.4.0/user/context_providers/index.html).
 - The URL associated to a registration is used to forward queries or updates to context providers covered by the 
   registration.
 - In the case of query forwarding, the context provider will send the query result to Context Broker
   as part of the query response. Thus, there is an information flow from context providers to Context Broker.
 - By the time being at IoT platform v4.1, registrations management is not yet part of the NGSIv2, so the old 
   NGSIv1 API has to be used. However, the query/udpates forwarded as result of the registrations can use 
-  NGSIv2 without problems. More details about this coexistence [here](http://fiware-orion.readthedocs.io/en/master/user/v1_v2_coexistence/index.html#ngsiv2-query-update-forwarding-to-context-providers).
+  NGSIv2 without problems. More details about this coexistence [here](http://fiware-orion.readthedocs.io/en/1.4.0/user/v1_v2_coexistence/index.html#ngsiv2-query-update-forwarding-to-context-providers).
  

--- a/docs/topics/user_permissions.md
+++ b/docs/topics/user_permissions.md
@@ -36,11 +36,11 @@ to do some actions or not.
 
 In deep details, each Role in a Service is defined by a Policy for each IoTP component:
 
-- [IoTP Policies](https://github.com/telefonicaid/orchestrator/tree/master/src/orchestrator/core/policies)
-- [Orion component actions](https://github.com/telefonicaid/fiware-pep-steelskin#-rules-to-determine-the-context-broker-action-from-the-request)
-- [Perseo component actions](https://github.com/telefonicaid/fiware-pep-steelskin#-rules-to-determine-the-perseo-cep-action-from-the-request)
-- [Keypass component actions](https://github.com/telefonicaid/fiware-pep-steelskin#rulesKeypass)
-- [Rest API based components (STH, IOTA) actions](https://github.com/telefonicaid/fiware-pep-steelskin#generic-rest-middleware)
+- [IoTP Policies](https://github.com/telefonicaid/orchestrator/tree/1.4.0/src/orchestrator/core/policies)
+- [Orion component actions](https://github.com/telefonicaid/fiware-pep-steelskin/tree/release/1.2.0#-rules-to-determine-the-context-broker-action-from-the-request)
+- [Perseo component actions](https://github.com/telefonicaid/fiware-pep-steelskin/tree/release/1.2.0#-rules-to-determine-the-perseo-cep-action-from-the-request)
+- [Keypass component actions](https://github.com/telefonicaid/fiware-pep-steelskin/tree/release/1.2.0#-rules-to-determine-the-keypass-access-control-action-from-the-request)
+- [Rest API based components (STH, IOTA) actions](https://github.com/telefonicaid/fiware-pep-steelskin/tree/release/1.2.0#generic-rest-middleware)
 
 Since [Identity Management](../authentication_api.md) of IoT Platform is based on [OpenStack Keystone](http://docs.openstack.org/developer/keystone) the following table represents relations between involved concepts:
 
@@ -73,7 +73,7 @@ To create a new user with special permission you should do the following steps:
 - Create a new Role.
 [Orchestrator how to create a new role](http://docs.orchestrator2.apiary.io/#reference/orchestrator/roles-in-service/create-a-role)
 
-- Define a new custom XACML Policy, like one of [these](https://github.com/telefonicaid/orchestrator/tree/master/src/orchestrator/core/policies)
+- Define a new custom XACML Policy, like one of [these](https://github.com/telefonicaid/orchestrator/tree/1.4.0/src/orchestrator/core/policies)
 
 - Assign a XACMLpolicy for that role and each IoTP component that you need.
 [Set a XACML policy to a Role](http://docs.orchestrator2.apiary.io/#reference/orchestrator/role-in-service/set-xacml-policy-role)


### PR DESCRIPTION
```
$ grep -r "master" docs/
docs//externals/fiware-orion/doc/manuals/admin/cli.md:    script](https://github.com/telefonicaid/fiware-orion/blob/master/scripts/httpsPrepare.sh)
docs//externals/fiware-orion/doc/manuals/admin/cli.md:    script](https://github.com/telefonicaid/fiware-orion/blob/master/scripts/httpsPrepare.sh)
docs//externals/fiware-orion/doc/manuals/admin/resources.md:    flows (e.g. the synchronization between master and slaves in a
docs//externals/fiware-orion/doc/manuals/quick_start_guide.md:    # wget --no-check-certificate https://raw.githubusercontent.com/fgalan/oauth2-example-orion-client/master/token_script.sh
docs//externals/fiware-orion/doc/manuals/user/walkthrough_apiv1.md:GitHub](https://github.com/telefonicaid/fiware-orion/blob/master/scripts/accumulator-server.py).
docs//topics/data_calculation.md:the [specification](https://github.com/telefonicaid/iotagent-node-lib/blob/master/doc/expressionLanguage.md).
docs//topics/geolocalized_entities.md:    at Carto. See [Cygnus documentation](http://fiware-cygnus.readthedocs.io/en/master/cygnus-ngsi/flume_extensions_catalogue/ngsi_cartodb_sink/index.html#section2.3.6) for more detail.
```

```
$ grep -r "develop" docs/
docs//cep.md:CEP APIs allows developers to manage rules exposing CRUD operations, and feed it with NGSI10 notifications to trigger those rules.
docs//device_api.md:Finally, after connecting your IoT devices this way you (or any other developer with the right access permissions) should be able to use the Data API to read the NGSI entity assigned to your device or see the data on the Management Portal.
docs//device_gateway.md:device specific platform and the platform standard model (NGSI). For that, different IoT Agents development frameworks
docs//externals/fiware-orion/doc/manuals/admin/cli.md:    [here](https://github.com/telefonicaid/fiware-orion/blob/develop/src/lib/logMsg/traceLevels.h)
docs//externals/fiware-orion/doc/manuals/admin/database_admin.md:location](https://github.com/telefonicaid/fiware-orion/tree/develop/test/LoadTest)
docs//externals/fiware-orion/doc/manuals/admin/logs.md:    log message. This information is useful for developers only.
docs//externals/fiware-orion/doc/manuals/admin/logs.md:    (this information is useful mainly for Orion developers).
docs//externals/fiware-orion/doc/manuals/admin/logs.md:    This type of errors should be reported to the Orion development team
docs//externals/fiware-orion/doc/manuals/admin/logs.md:    development team using the appropriate channel (StackOverflow with
docs//externals/fiware-orion/doc/manuals/admin/logs.md:| 3          | CRITICAL   | The following ERROR text appears in the 'msg' field: "Runtime Error (...)"                    | N/A                                                                                                                                                                                                                                                      | Runtime Error. The text within parenthesis in the 'msg' field containts the detailed information.            | Restart Orion Context Broker. If it persits (e.g. new Runtime Errors appear within the next hour), scale up the problem to development team.
docs//externals/fiware-orion/doc/manuals/admin/resources.md:Broker, tests done in our development and testing environment show that
docs//externals/fiware-orion/doc/manuals/code_contributions.md:external developers) that can be used as examples for programming with
docs//externals/fiware-orion/doc/manuals/code_contributions.md:<https://github.com/KurentoLegacy/kmf-orion-connector/tree/develop>
docs//externals/fiware-orion/doc/manuals/user/context_providers.md:The Context Providers and request forwarding functionality was developed
docs//externals/fiware-orion/doc/manuals/user/walkthrough_apiv1.md:be sent in this case or not. On one hand, some developers have told us
docs//externals/fiware-orion/doc/manuals/user/walkthrough_apiv1.md:one hand, some developers have told us that it might be useful to know
docs//externals/fiware-orion/doc/manuals/vagrant.md:If you want yo have an Orion Context Broker ready to develop in your machine easily we provide a Vagrant file so that you can get up and running. Just run:
docs//externals/fiware-orion/doc/manuals/vagrant.md:You just need to install Vagrant if you want to use this, and at least Virtualbox. Especially useful for those that use virtual machines to develop on a Mac or a Linux distribution that is not CentOS. Keep in mind that the Vagrant file specifies CentOS 6.5 as a base operating system.
docs//index.md:- Device-independent APIs for quick app development & lock-in prevention
docs//security.md:You, as a developer, may wonder what a subject is, and why policies are grouped around them. To simplify, a subject is
docs//security.md:[Keystone](http://developer.openstack.org/api-ref-identity-v3.html)
docs//topics/cep_new_actions.md:This set is enhanced from time to time adding new actions, according to IoT platform development roadmap.
docs//topics/cep_new_actions.md:* Request the development of the new action as part of the CEP actions set. In this case, please [fill 
docs//topics/user_permissions.md:Since [Identity Management](../authentication_api.md) of IoT Platform is based on [OpenStack Keystone](http://docs.openstack.org/developer/keystone) the following table represents relations between involved concepts:
docs//topics/which_historical_backend.md:No visualization tools are given with STH Comet. Nevertheless, its REST API could be integrated by a skilled developer with some tools such as [Grafana](http://grafana.org/).
```