### PR TITLE
Update device_api.md

### DIFF
--- a/docs/device_api.md
+++ b/docs/device_api.md
@@ -444,10 +444,10 @@ This example will tell the Robot 1 to turn to left.
 In the case of complex commands requiring parameters, the `commandValue` could be used to implement parameter passing. E.g:
 
 ```
-weatherStation167@ping|param1:1|param2:2
+weatherStation167@ping|param1=1|param2=2
 ```
 
-This example will tell the Weather Station 167 to reply to a ping message with the provided params. Note that `=` cannot be used instead of `:` given that `=` is [a forbidden character for Context Broker](https://fiware-orion.readthedocs.io/en/master/user/forbidden_characters/index.html), so the update at CB triggering the command would be never progressed.
+This example will tell the Weather Station 167 to reply to a ping message with the provided params. Regarding with param value format of a commandValue note that `=` cannot be used instead of `:` given that `=` is [a forbidden character for Context Broker](https://fiware-orion.readthedocs.io/en/master/user/forbidden_characters/index.html), so the update at CB triggering the command would be never progressed.
 
 Once the command has finished its execution in the device, the reply to the IOTA must adhere to the following format:
 


### PR DESCRIPTION
Los comandos UL que genera el portal son siguen el formato recomendado:
https://fiware-iot-stack.readthedocs.io/en/master/device_api/index.html#command-payloads.
i.e.:
- ```{ "type": "command", "value": ""} ```
- ```{ "type": "command", "value": { "param1": "value1"} ```

que genaran los comandos de UL respectivamente
- led
- led|param1=value1

A su vez los value de los parámetros pueden tener formato "algo:value1" pero no "algo=value1" (no lo admite el ContextBroker), traduciéndose el ejemplo correcto a:
- led|param1=algo:value1


La documentación del protocolo de Ultralight 2.0 no es correcta en la parte de comandos. Según la imiplementación del parser en https://github.com/telefonicaid/iotagent-ul/blob/master/lib/ulParser.js#L138 el separador de los valores de los parametros de los comandos es ```=``` no ```:``` que es lo que dice la documentación en https://github.com/telefonicaid/iotagent-ul/blob/master/docs/usermanual.md#commands-syntax ```weatherStation167@ping|param1:1|param2:2``` deberia ser ```weatherStation167@ping|param1=1|param2=2``` IMHO

Los test de UL tambien avalan esta teoria. https://github.com/telefonicaid/iotagent-ul/blob/master/test/unit/ultralitghtCommands-test.js#L32