### PR TITLE
[WIP] Fix broken java-examples build in jdk>=9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ branches:
       - /.*/
 
 install:
-  - mvn package
+  - cd java-examples && mvn package
 
 before_install:
-  - mvn clean
+  - cd java-examples && mvn clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ branches:
 
 script:
   - cd java-examples
+  - mvn clean
   - mvn package
-
-#before_script:
-#  - cd java-examples
-#  - mvn clean
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ branches:
 
 script:
   - cd java-examples
+  - mvn -version
   - mvn clean
   - mvn package
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,5 @@ script:
   - mvn package
 
 before_script:
+  - cd java-examples
   - mvn clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,10 @@ branches:
       - /.*/
 
 install:
-  - cd java-examples && mvn package
+  - mvn package
 
 before_install:
-  - cd java-examples && mvn clean
+  - mvn clean
+  
+before_script:
+  - cd java-examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,3 @@ install:
 
 before_install:
   - mvn clean
-  
-before_script:
-  - cd java-examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ script:
   - cd java-examples
   - mvn package
 
-before_script:
-  - cd java-examples
-  - mvn clean
+#before_script:
+#  - cd java-examples
+#  - mvn clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,9 @@ branches:
     only:
       - /.*/
 
-install:
+script:
+  - cd java-examples
   - mvn package
 
-before_install:
+before_script:
   - mvn clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ branches:
 script:
   - cd java-examples
   - mvn -version
+  - which javac
   - mvn clean
   - mvn package
   

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ repo-name3=release/1.3.0
 repo-nameN=release/1.4.0
 ```
 
-The 1.1.0, 1.2.0, etc. above are just example; use actual version number in a real case. 
+The 1.1.0, 1.2.0, etc. above are just example; use actual version number in a real case.  

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ repo-name3=release/1.3.0
 repo-nameN=release/1.4.0
 ```
 
-The 1.1.0, 1.2.0, etc. above are just example; use actual version number in a real case.
+The 1.1.0, 1.2.0, etc. above are just example; use actual version number in a real case. 

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ repo-name3=release/1.3.0
 repo-nameN=release/1.4.0
 ```
 
-The 1.1.0, 1.2.0, etc. above are just example; use actual version number in a real case.  
+The 1.1.0, 1.2.0, etc. above are just example; use actual version number in a real case.

--- a/java-examples/pom.xml
+++ b/java-examples/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
-            <version>2.3.4</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/java-examples/pom.xml
+++ b/java-examples/pom.xml
@@ -27,7 +27,8 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
-            <version>1.2.0</version>
+            <!--version>1.2.0</version-->
+            <version>2.3.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
PR https://github.com/telefonicaid/fiware-iot-stack/pull/96 upgraded a package in pom.xml to solve a vulnerability reported by github but it seems it breaks the java-examples build.

Up to commit 84f0931 in this PR I has been playing with .travis.yml adjustment (I know: too noise, it will be rebased before merging ;). At that commit travis report you can see: 

![imagen](https://user-images.githubusercontent.com/1534240/48918609-fc919980-ee8d-11e8-9b6e-9fe69703ac9b.png)

Last commit (`64fb162`) reverts the pom.xml change done by PR #96 and now all gets green.

I think that downgrading package version should be avoided (as we would re-introduce a vulnerability) but we need to fix the build in another way. Maybe pom.xml needs some additional configuration?

CC: @AlvaroVega 